### PR TITLE
fix(testdata): load should not clobber initial values when decoding json

### DIFF
--- a/testdata.go
+++ b/testdata.go
@@ -160,11 +160,12 @@ func loadFile(file string, field reflect.StructField, value reflect.Value, tag *
 
 	// structured types
 	if filepath.Ext(file) == ".json" {
-		v := reflect.New(value.Type()).Interface()
-		if err := json.Unmarshal(data, v); err != nil {
+		p := reflect.New(value.Type())
+		p.Elem().Set(value) // preserve any prior values
+		if err := json.Unmarshal(data, p.Interface()); err != nil {
 			return fmt.Errorf("%s: failed to parse contents of %s as JSON: %w", field.Name, file, err)
 		}
-		value.Set(reflect.ValueOf(v).Elem())
+		value.Set(p.Elem()) // overwrite with the value modified by json Unmarshal
 		return nil
 	}
 

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -47,6 +47,22 @@ func TestLoadDir(t *testing.T) {
 			}{"world"}},
 		},
 		{
+			name: "json should not clobber",
+			dir:  "json",
+			input: &testJSONMap{
+				Input: map[string]interface{}{
+					"hello": "dave", // should be overwritten
+					"a":     "A",    // should not be deleted
+				},
+			},
+			expected: &testJSONMap{
+				Input: map[string]interface{}{
+					"hello": "world",
+					"a":     "A",
+				},
+			},
+		},
+		{
 			name:  "json map",
 			dir:   "json",
 			input: &testJSONMap{},

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -16,61 +16,70 @@ func TestLoadDir(t *testing.T) {
 	spec := []struct {
 		name     string
 		dir      string
+		input    interface{}
 		expected interface{}
 		fail     bool
 	}{
 		{
 			name:     "string",
 			dir:      "text",
-			expected: testTextString{Input: "hello world"},
+			input:    &testTextString{},
+			expected: &testTextString{Input: "hello world"},
 		},
 		{
 			name:     "bytes",
 			dir:      "text",
-			expected: testTextBytes{Input: []byte("hello world")},
+			input:    &testTextBytes{},
+			expected: &testTextBytes{Input: []byte("hello world")},
 		},
 		{
 			name:     "json raw",
 			dir:      "json",
-			expected: testJSONRaw{Input: json.RawMessage("{\n  \"hello\": \"world\"\n}")},
+			input:    &testJSONRaw{},
+			expected: &testJSONRaw{Input: json.RawMessage("{\n  \"hello\": \"world\"\n}")},
 		},
 		{
-			name: "json struct",
-			dir:  "json",
-			expected: testJSONStruct{Input: struct {
+			name:  "json struct",
+			dir:   "json",
+			input: &testJSONStruct{},
+			expected: &testJSONStruct{Input: struct {
 				Hello string `json:"hello"`
 			}{"world"}},
 		},
 		{
-			name: "json map",
-			dir:  "json",
-			expected: testJSONMap{
+			name:  "json map",
+			dir:   "json",
+			input: &testJSONMap{},
+			expected: &testJSONMap{
 				Input: map[string]interface{}{"hello": "world"},
 			},
 		},
 		{
-			name:     "json invalid",
-			dir:      "json",
-			expected: testJSONInvalid{},
-			fail:     true,
+			name:  "json invalid",
+			dir:   "json",
+			input: &testJSONInvalid{},
+			fail:  true,
 		},
 		{
 			name:     "json optional",
 			dir:      "json",
-			expected: testJSONOptional{},
+			input:    &testJSONOptional{},
+			expected: &testJSONOptional{},
 		},
 		{
-			name: "multiple",
-			dir:  "multiple",
-			expected: testMultiple{
+			name:  "multiple",
+			dir:   "multiple",
+			input: &testMultiple{},
+			expected: &testMultiple{
 				A: "A",
 				B: []byte("B"),
 			},
 		},
 		{
-			name: "multiple map",
-			dir:  "multiple",
-			expected: testMultipleMap{
+			name:  "multiple map",
+			dir:   "multiple",
+			input: &testMultipleMap{},
+			expected: &testMultipleMap{
 				Files: map[string]string{
 					"a.txt": "A",
 					"b.txt": "B",
@@ -78,36 +87,40 @@ func TestLoadDir(t *testing.T) {
 			},
 		},
 		{
-			name:     "not pointer",
-			dir:      "text",
-			expected: struct{}{},
-			fail:     true,
+			name:  "not pointer",
+			dir:   "text",
+			input: struct{}{},
+			fail:  true,
 		},
 		{
-			name:     "missing file",
-			dir:      "text",
-			expected: testTextMissing{},
-			fail:     true,
+			name:  "missing file",
+			dir:   "text",
+			input: &testTextMissing{},
+			fail:  true,
 		},
 		{
 			name:     "missing optional file",
 			dir:      "text",
-			expected: testTextMissingOptional{},
+			input:    &testTextMissingOptional{},
+			expected: &testTextMissingOptional{},
 		},
 		{
 			name:     "missing struct tag",
 			dir:      "text",
-			expected: testMissingStructTag{},
+			input:    &testMissingStructTag{},
+			expected: &testMissingStructTag{},
 		},
 		{
 			name:     "empty struct tag",
 			dir:      "text",
-			expected: testEmptyStructTag{},
+			input:    &testEmptyStructTag{},
+			expected: &testEmptyStructTag{},
 		},
 		{
 			name:     "dash struct tag",
 			dir:      "text",
-			expected: testDashStructTag{},
+			input:    &testDashStructTag{},
+			expected: &testDashStructTag{},
 		},
 		{
 			name: "nil",
@@ -118,22 +131,12 @@ func TestLoadDir(t *testing.T) {
 
 	for _, test := range spec {
 		t.Run(test.name, func(t *testing.T) {
-			var input interface{}
-			if test.expected != nil {
-				if s, ok := test.expected.(struct{}); ok {
-					input = s
-				} else {
-					input = reflect.New(reflect.TypeOf(test.expected)).Interface()
-				}
-			}
-
-			err := loadDir(filepath.Join("testdata", test.dir), input)
+			err := loadDir(filepath.Join("testdata", test.dir), test.input)
 			if test.fail {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				actual := reflect.ValueOf(input).Elem().Interface()
-				require.EqualValues(t, test.expected, actual)
+				require.EqualValues(t, test.expected, test.input)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, if you supply a struct/map with initial values prior to calling `got.LoadTestData`, those values will be lost as we simply create a new variable with that type before calling into `json.Unmarshal`.

This fixes that bug by carrying over any previous values before decoding as JSON.