### PR TITLE
feat(testdata): put special treatment for maps behind a struct tag option

### DIFF
--- a/testdata.go
+++ b/testdata.go
@@ -162,7 +162,7 @@ func loadDir(inputs []string, output any) error {
 func loadDirInput(input string, tag *structtag.Tag, field reflect.StructField, value reflect.Value) error {
 	file := filepath.Join(input, tag.Name)
 
-	if isMap(field.Type) {
+	if isMap(field.Type) && tag.HasOption("explode") {
 		matches, err := filepath.Glob(file)
 		if err != nil {
 			return fmt.Errorf("%s: failed to list files %s: %w", field.Name, file, err)
@@ -270,7 +270,7 @@ func saveDir(dir string, input any) error {
 }
 
 func saveDirField(dir string, tag *structtag.Tag, field reflect.StructField, value reflect.Value) error {
-	if isMap(field.Type) {
+	if isMap(field.Type) && tag.HasOption("explode") {
 		iter := value.MapRange()
 
 		for iter.Next() {

--- a/testdata_test.go
+++ b/testdata_test.go
@@ -117,9 +117,19 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("maps", func(t *testing.T) {
+		t.Run("raw json", func(t *testing.T) {
+			type test struct {
+				Input map[string]any `testdata:"input.json"`
+			}
+
+			testLoadOne(t, "json", new(test), &test{
+				Input: map[string]any{"hello": "world"},
+			})
+		})
+
 		t.Run("expand glob", func(t *testing.T) {
 			type test struct {
-				Multiple map[string]string `testdata:"*.txt"`
+				Multiple map[string]string `testdata:"*.txt,explode"`
 			}
 
 			testLoadOne(t, "multiple", new(test), &test{
@@ -132,7 +142,7 @@ func TestLoad(t *testing.T) {
 
 		t.Run("single file", func(t *testing.T) {
 			type test struct {
-				Multiple map[string]string `testdata:"a.txt"`
+				Multiple map[string]string `testdata:"a.txt,explode"`
 			}
 
 			testLoadOne(t, "multiple", new(test), &test{
@@ -144,7 +154,7 @@ func TestLoad(t *testing.T) {
 
 		t.Run("bytes", func(t *testing.T) {
 			type test struct {
-				Multiple map[string][]byte `testdata:"a.txt"`
+				Multiple map[string][]byte `testdata:"a.txt,explode"`
 			}
 
 			testLoadOne(t, "multiple", new(test), &test{
@@ -156,7 +166,7 @@ func TestLoad(t *testing.T) {
 
 		t.Run("glob without matches", func(t *testing.T) {
 			type test struct {
-				Multiple map[string]string `testdata:"*.log"`
+				Multiple map[string]string `testdata:"*.log,explode"`
 			}
 
 			testLoadOne(t, "multiple", new(test), &test{
@@ -366,9 +376,17 @@ func TestAssert(t *testing.T) {
 				},
 			},
 			{
-				name: "map",
+				name: "map json",
 				expected: &struct {
-					Files map[string]string `testdata:"*.txt"`
+					Input map[string]string `testdata:"input.json"`
+				}{
+					Input: map[string]string{"hello": "world"},
+				},
+			},
+			{
+				name: "map explode",
+				expected: &struct {
+					Files map[string]string `testdata:"*.txt,explode"`
 				}{
 					Files: map[string]string{"a.txt": "A", "b.txt": "B"},
 				},


### PR DESCRIPTION
Early on, there was special treatment for maps which used the keys as globs which would expand out into multiple files. While this feature still has utility, as a default it usually creates confusion, as something innocuous like using `map[string]any` would behave counter-intuitively.

As a result, the special map behavior is being put behind a new struct tag option, "explode" and will need to be opted in. 